### PR TITLE
fix: add type, EIP712Domain, in message for EIP712 sign

### DIFF
--- a/src/stores/zkopru.js
+++ b/src/stores/zkopru.js
@@ -255,6 +255,11 @@ export default {
         },
         primaryType: 'ZkopruKey',
         types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+          ],
           ZkopruKey: [
             { name: 'info', type: 'string', },
             { name: 'warning', type: 'string', },

--- a/src/stores/zkopru.js
+++ b/src/stores/zkopru.js
@@ -275,12 +275,13 @@ export default {
       console.log('rootState.account.accounts[0]', rootState.account.accounts[0])
       return state.walletKey
     },
-    loadWallet: async ({ state, commit, dispatch }) => {
+    loadWallet: async ({ state, commit, dispatch, rootState }) => {
       const key = await dispatch('loadWalletKey')
       const { default: Zkopru } = await import(/* webpackPrefetch: true */ '@zkopru/client/browser')
       state.wallet = new Zkopru.Wallet(
         state.client,
-        key
+        key,
+        rootState.account.accounts[0]
       )
       const { address } = state.wallet.wallet.account.zkAddress
       console.log('zkAddress', address)

--- a/tx-generator.js
+++ b/tx-generator.js
@@ -15,7 +15,8 @@ const PUBLIC_KEY = '0x3537256fFB47da602871bE7FB26d9fe7e42dD055'
   await client.start(':memory:')
   const wallet = new Zkopru.Wallet(
     client,
-    key
+    key,
+    rootState.account.accounts[0]
   )
   for (;;) {
     try {


### PR DESCRIPTION
Data type definition, `EIP712Domain`, should be added in the `types` section. After adding `EIP712Domain` the signature will be the same as `ethers.singer._signTypedData`